### PR TITLE
Fix bad casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,7 +13,7 @@ analyzer:
     unused_local_variable: error
     use_string_in_part_of_directives: ignore
     curly_braces_in_flow_control_structures: ignore
-    unnecessary_library_name: ignore
+    unnecessary_library_name:  error
 
 linter:
 
@@ -94,6 +94,7 @@ linter:
     - omit_local_variable_types
     - prefer_final_in_for_each
     - prefer_final_locals
+    - use_string_in_part_of_directives
     # - avoid_setters_without_getters
     # - cascade_invocations
     # - avoid_positional_boolean_parameters

--- a/lib/src/animation/animation.dart
+++ b/lib/src/animation/animation.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class Animation {
   final String name;

--- a/lib/src/animation/animation_state.dart
+++ b/lib/src/animation/animation_state.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class AnimationState extends EventDispatcher {
   static const subsequent = 0;
@@ -344,7 +344,7 @@ class AnimationState extends EventDispatcher {
         if (lastTotal.abs() > 180.0) lastTotal += 360.0 * lastTotal.sign;
         dir = current;
       }
-      // Store loops as part of lastTotal.
+      // Store loops as part of '../stagexl_spine.dart';
       total = diff + 360.0 * (lastTotal / 360.0).truncateToDouble();
       if (dir != current) total += 360.0 * lastTotal.sign;
       timelinesRotation[i] = total;

--- a/lib/src/animation/animation_state_data.dart
+++ b/lib/src/animation/animation_state_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class AnimationStateData {
   final SkeletonData skeletonData;

--- a/lib/src/animation/attachment_timeline.dart
+++ b/lib/src/animation/attachment_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class AttachmentTimeline implements Timeline {
   final Float32List frames; // time, ...

--- a/lib/src/animation/color_timeline.dart
+++ b/lib/src/animation/color_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class ColorTimeline extends CurveTimeline {
   static const _entries = 5;

--- a/lib/src/animation/curve_timeline.dart
+++ b/lib/src/animation/curve_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 /// Base class for frames that use an interpolation bezier curve.
 ///

--- a/lib/src/animation/deform_timeline.dart
+++ b/lib/src/animation/deform_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class DeformTimeline extends CurveTimeline {
   final Float32List frames;

--- a/lib/src/animation/draw_order_timeline.dart
+++ b/lib/src/animation/draw_order_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class DrawOrderTimeline implements Timeline {
   final Float32List frames; // time, ...

--- a/lib/src/animation/event_timeline.dart
+++ b/lib/src/animation/event_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class EventTimeline implements Timeline {
   final Float32List frames; // time, ...

--- a/lib/src/animation/ik_constraint_timeline.dart
+++ b/lib/src/animation/ik_constraint_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class IkConstraintTimeline extends CurveTimeline {
   static const _entries = 3;

--- a/lib/src/animation/mix_direction.dart
+++ b/lib/src/animation/mix_direction.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 // ignore: constant_identifier_names
 enum MixDirection { In, Out }

--- a/lib/src/animation/mix_pose.dart
+++ b/lib/src/animation/mix_pose.dart
@@ -28,6 +28,6 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 enum MixPose { setup, current, currentLayered }

--- a/lib/src/animation/path_constraint_mix_timeline.dart
+++ b/lib/src/animation/path_constraint_mix_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class PathConstraintMixTimeline extends CurveTimeline {
   static const _entries = 3;

--- a/lib/src/animation/path_constraint_position_timeline.dart
+++ b/lib/src/animation/path_constraint_position_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class PathConstraintPositionTimeline extends CurveTimeline {
   static const _entries = 2;

--- a/lib/src/animation/path_constraint_spacing_timeline.dart
+++ b/lib/src/animation/path_constraint_spacing_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class PathConstraintSpacingTimeline extends PathConstraintPositionTimeline {
   static const _entries = 2;

--- a/lib/src/animation/rotate_timeline.dart
+++ b/lib/src/animation/rotate_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class RotateTimeline extends CurveTimeline {
   static const _entries = 2;

--- a/lib/src/animation/scale_timeline.dart
+++ b/lib/src/animation/scale_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class ScaleTimeline extends TranslateTimeline {
   static const _entries = 3;

--- a/lib/src/animation/shear_timeline.dart
+++ b/lib/src/animation/shear_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class ShearTimeline extends TranslateTimeline {
   static const _entries = 3;

--- a/lib/src/animation/timeline.dart
+++ b/lib/src/animation/timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 abstract class Timeline {
   /// Sets the value(s) for the specified time.

--- a/lib/src/animation/timeline_type.dart
+++ b/lib/src/animation/timeline_type.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class TimelineType {
   final int ordinal;

--- a/lib/src/animation/track_entry.dart
+++ b/lib/src/animation/track_entry.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class TrackEntry extends EventDispatcher {
   final int trackIndex;

--- a/lib/src/animation/track_entry_event.dart
+++ b/lib/src/animation/track_entry_event.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 abstract class TrackEntryEvent extends stagexl.Event {
   final TrackEntry trackEntry;

--- a/lib/src/animation/transform_constraint_timeline.dart
+++ b/lib/src/animation/transform_constraint_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class TransformConstraintTimeline extends CurveTimeline {
   static const _entries = 5;

--- a/lib/src/animation/translate_timeline.dart
+++ b/lib/src/animation/translate_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class TranslateTimeline extends CurveTimeline {
   static const _entries = 3;

--- a/lib/src/animation/two_color_timeline.dart
+++ b/lib/src/animation/two_color_timeline.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class TwoColorTimeline extends CurveTimeline {
   static const _entries = 8;

--- a/lib/src/attachments/attachment.dart
+++ b/lib/src/attachments/attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class Attachment {
   final String name;

--- a/lib/src/attachments/attachment_loader.dart
+++ b/lib/src/attachments/attachment_loader.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 abstract class AttachmentLoader {
   RegionAttachment? newRegionAttachment(Skin skin, String name, String path);

--- a/lib/src/attachments/attachment_type.dart
+++ b/lib/src/attachments/attachment_type.dart
@@ -28,6 +28,6 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 enum AttachmentType { region, regionsequence, boundingbox, mesh, linkedmesh, path, point, clipping }

--- a/lib/src/attachments/bounding_box_attachment.dart
+++ b/lib/src/attachments/bounding_box_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class BoundingBoxAttachment extends VertexAttachment {
   BoundingBoxAttachment(super.name);

--- a/lib/src/attachments/clipping_attachment.dart
+++ b/lib/src/attachments/clipping_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class ClippingAttachment extends VertexAttachment {
   SlotData? endSlot;

--- a/lib/src/attachments/mesh_attachment.dart
+++ b/lib/src/attachments/mesh_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class MeshAttachment extends RenderAttachment {
   late Float32List regionUVs;

--- a/lib/src/attachments/path_attachment.dart
+++ b/lib/src/attachments/path_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class PathAttachment extends VertexAttachment {
   late final Float32List lengths;

--- a/lib/src/attachments/point_attachment.dart
+++ b/lib/src/attachments/point_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class PointAttachment extends VertexAttachment {
   double x = 0;

--- a/lib/src/attachments/region_attachment.dart
+++ b/lib/src/attachments/region_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class RegionAttachment extends RenderAttachment {
   double x = 0;

--- a/lib/src/attachments/render_attachment.dart
+++ b/lib/src/attachments/render_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 abstract class RenderAttachment extends VertexAttachment {
   final String path;

--- a/lib/src/attachments/vertex_attachment.dart
+++ b/lib/src/attachments/vertex_attachment.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class VertexAttachment extends Attachment {
   static int _nextID = 0;

--- a/lib/src/bone.dart
+++ b/lib/src/bone.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class Bone implements Updatable {
   final BoneData data;

--- a/lib/src/bone_data.dart
+++ b/lib/src/bone_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class BoneData {
   final int index;

--- a/lib/src/constraint.dart
+++ b/lib/src/constraint.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 abstract class Constraint extends Updatable {
   int getOrder();

--- a/lib/src/event_data.dart
+++ b/lib/src/event_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class EventData {
   final String name;

--- a/lib/src/ik_constraint.dart
+++ b/lib/src/ik_constraint.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class IkConstraint implements Constraint {
   final List<Bone> bones = [];

--- a/lib/src/ik_constraint_data.dart
+++ b/lib/src/ik_constraint_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class IkConstraintData {
   final String name;

--- a/lib/src/math_util.dart
+++ b/lib/src/math_util.dart
@@ -1,4 +1,4 @@
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 /// multiplier for degrees to radians conversion
 double _deg2rad = math.pi / 180.0;

--- a/lib/src/path_constraint.dart
+++ b/lib/src/path_constraint.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class PathConstraint implements Constraint {
   static const _none = -1;

--- a/lib/src/path_constraint_data.dart
+++ b/lib/src/path_constraint_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class PathConstraintData {
   final String name;

--- a/lib/src/position_mode.dart
+++ b/lib/src/position_mode.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 enum PositionMode { 
   fixed, percent;

--- a/lib/src/rotate_mode.dart
+++ b/lib/src/rotate_mode.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 enum RotateMode {
   tangent, 

--- a/lib/src/skeleton.dart
+++ b/lib/src/skeleton.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class Skeleton {
   final SkeletonData data;

--- a/lib/src/skeleton_bounds.dart
+++ b/lib/src/skeleton_bounds.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class SkeletonBounds {
   final List<BoundingBoxAttachment> boundingBoxes = [];

--- a/lib/src/skeleton_data.dart
+++ b/lib/src/skeleton_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class SkeletonData {
   String? name = '';

--- a/lib/src/skeleton_loader.dart
+++ b/lib/src/skeleton_loader.dart
@@ -862,8 +862,8 @@ class SkeletonLoader {
   }
 
   Float32List _getFloat32List(Json map, String name) {
-    final values = map[name].getList<double>();
-    return Float32List.fromList(values);
+    final values = map[name].getList<num>().map((n) => n.toDouble());
+    return Float32List.fromList(values.toList());
   }
 
   Int16List _getInt16List(Json map, String name) {

--- a/lib/src/skeleton_loader.dart
+++ b/lib/src/skeleton_loader.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 extension on Object? {
   // ignore: cast_nullable_to_non_nullable

--- a/lib/src/skin.dart
+++ b/lib/src/skin.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 /// Stores attachments by slot index and attachment name.
 ///

--- a/lib/src/slot.dart
+++ b/lib/src/slot.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class Slot {
   final SlotData data;

--- a/lib/src/slot_data.dart
+++ b/lib/src/slot_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class SlotData {
   final int index;

--- a/lib/src/spacing_mode.dart
+++ b/lib/src/spacing_mode.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 enum SpacingMode { 
   fixed, 

--- a/lib/src/spine_color.dart
+++ b/lib/src/spine_color.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class SpineColor {
   //static final Color WHITE = new Color(1.0, 1.0, 1.0, 1.0);

--- a/lib/src/spine_event.dart
+++ b/lib/src/spine_event.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class SpineEvent {
   final double time;

--- a/lib/src/stagexl/skeleton_animation.dart
+++ b/lib/src/stagexl/skeleton_animation.dart
@@ -1,4 +1,4 @@
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class SkeletonAnimation extends SkeletonDisplayObject implements Animatable {
   final AnimationState state;

--- a/lib/src/stagexl/skeleton_clipping.dart
+++ b/lib/src/stagexl/skeleton_clipping.dart
@@ -1,4 +1,4 @@
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class SkeletonClipping implements RenderMask {
   final Graphics _graphics = Graphics();

--- a/lib/src/stagexl/skeleton_display_object.dart
+++ b/lib/src/stagexl/skeleton_display_object.dart
@@ -1,4 +1,4 @@
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 enum SkeletonBoundsCalculation { none, boundingBoxes, hull }
 

--- a/lib/src/stagexl/texture_atlas_attachment_loader.dart
+++ b/lib/src/stagexl/texture_atlas_attachment_loader.dart
@@ -1,4 +1,4 @@
-part of stagexl_spine;
+part of '../../stagexl_spine.dart';
 
 class TextureAtlasAttachmentLoader implements AttachmentLoader {
   final TextureAtlas textureAtlas;

--- a/lib/src/transform_constraint.dart
+++ b/lib/src/transform_constraint.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class TransformConstraint implements Constraint {
   final TransformConstraintData data;

--- a/lib/src/transform_constraint_data.dart
+++ b/lib/src/transform_constraint_data.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 class TransformConstraintData {
   final String name;

--- a/lib/src/transform_mode.dart
+++ b/lib/src/transform_mode.dart
@@ -28,6 +28,6 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 enum TransformMode { normal, onlyTranslation, noRotationOrReflection, noScale, noScaleOrReflection }

--- a/lib/src/updatable.dart
+++ b/lib/src/updatable.dart
@@ -28,7 +28,7 @@
 /// POSSIBILITY OF SUCH DAMAGE.
 ///***************************************************************************
 
-part of stagexl_spine;
+part of '../stagexl_spine.dart';
 
 // ignore: one_member_abstracts
 abstract class Updatable {

--- a/lib/stagexl_spine.dart
+++ b/lib/stagexl_spine.dart
@@ -1,4 +1,4 @@
-library stagexl_spine;
+library;
 
 import 'dart:convert';
 import 'dart:math' as math;


### PR DESCRIPTION
Two patches here. The first enables the `unnecessary_library_names` lint, as this was causing issues in VSCode IntelliSense. The second fixes a cast-safety regression that broke SkeletonLoader when running in WASM.